### PR TITLE
Solves: there is only one entity updating for each type if one of required attribute is empty

### DIFF
--- a/packages/medusa-strapi/src/utils/utils.js
+++ b/packages/medusa-strapi/src/utils/utils.js
@@ -260,7 +260,13 @@ async function getStrapiEntityByUniqueField(uid, strapi, dataReceived) {
 		for (const field of uniqueFields) {
 			const filters = {};
 			filters[field] = dataReceived[field];
-			try {
+
+      // we're not iterating over empty fields as they're not unique
+      if (dataReceived[field] === null || dataReceived[field] === '') {
+        continue;
+      }
+
+      try {
 				const entity = await strapi.entityService.findMany(uid, {
 					filters,
 					fields: ['id', ...uniqueFields],


### PR DESCRIPTION
Suppose we use official Medusa fixtures or do not use one of the unique attributes at all. In that case, the sync mechanism will override the previous entity with an empty attribute thinking it's the same. 

Unfortunately, the empty attributes shouldn't be counted as unique, we should skip the comparison in such case. 