### PR TITLE
fix: Remove product relations sync due to redundant fields being sent

### DIFF
--- a/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
+++ b/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
@@ -832,14 +832,16 @@ export class UpdateStrapiService extends TransactionBaseService {
 			}
 			const product = await this.productService_.retrieve(data.id, {
 				relations: [
-					'options',
-					'variants',
-					'variants.prices',
-					'variants.options',
-					'type',
-					'collection',
-					'tags',
-					'images',
+					// As for now, we can't update relations due to issue with redundant fields
+					// We should pick which fields we want to synchronise from product relations
+					// 'options',
+					// 'variants',
+					// 'variants.prices',
+					// 'variants.options',
+					// 'type',
+					// 'collection',
+					// 'tags',
+					// 'images',
 				],
 				select: [
 					'id',


### PR DESCRIPTION
There seems to be a bug on the Strapi side, where the CMS is not accepting fields from outside the schema. To resolve this issue, it is recommended to filter the fields related to the product, so that Strapi can update them in accordance with its contract.

At present, the relations have been commented out, which means that the application is still functioning properly.