### PR TITLE
fix: Entities are not updated on medusa due to incorrect payload

### DIFF
--- a/packages/medusa-plugin-strapi-ts/src/api/controllers/hooks/update-medusa.ts
+++ b/packages/medusa-plugin-strapi-ts/src/api/controllers/hooks/update-medusa.ts
@@ -1,9 +1,23 @@
 import UpdateMedusaService from '../../../services/update-medusa';
+import * as jwt from "jsonwebtoken";
+import {ConfigModule} from "@medusajs/medusa/dist/types/global";
+import {StrapiSignalInterface} from "./strapi-signal";
+
+export interface UpdateMedusaDataInterface {
+	type: string;
+	data: any;
+}
+
 
 export default async (req, res, next) => {
+	const config = req.scope.resolve('configModule') as ConfigModule;
+	const updateMedusaService = req.scope.resolve('updateMedusaService') as UpdateMedusaService;
+
 	try {
-		const body = req.body;
-		const updateMedusaService = req.scope.resolve('updateMedusaService') as UpdateMedusaService;
+		const medusaSecret = config.projectConfig.jwt_secret;
+		const signedMessage = req.body['signedMessage'];
+		const signalRequest = jwt.verify(signedMessage, medusaSecret) as StrapiSignalInterface;
+		const body = signalRequest.data as UpdateMedusaDataInterface;
 
 		// find Strapi entry type from body of webhook
 		const strapiType = body.type;
@@ -21,7 +35,6 @@ export default async (req, res, next) => {
 				updated = await updateMedusaService.sendStrapiProductVariantToMedusa(body.data, entryId);
 				break;
 			case 'region':
-				console.log('region');
 				entryId = body.data.medusa_id;
 				updated = await updateMedusaService.sendStrapiRegionToMedusa(body.data, entryId);
 				break;


### PR DESCRIPTION
As the title suggests, the request was not decrypted, and as a result, changes made on the strapi side are not updating the entities.