### PR TITLE
feat: updates with relations, feat: updating products in collections, fix: corrections in relations

### DIFF
--- a/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
+++ b/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
@@ -407,7 +407,7 @@ export class UpdateStrapiService extends TransactionBaseService {
 				productToSend['product-variants'] = _.cloneDeep(productToSend.variants);
 				delete productToSend.variants;
 
-				productToSend['product-collections'] = _.cloneDeep(productToSend.collection);
+				productToSend['product-collection'] = _.cloneDeep(productToSend.collection);
 				delete productToSend.collection;
 
 				productToSend['product-categories'] = _.cloneDeep(productToSend.categories);
@@ -918,12 +918,16 @@ export class UpdateStrapiService extends TransactionBaseService {
 	}
 
 	private async adjustProductAndUpdateInStrapi(product: Product, data, authInterface: AuthInterface) {
-		// Medusa is not using consistent naming for product-collection.
-		// We have to adjust it manually from collection to product-collection
+		// Medusa is not using consistent naming for product-*.
+		// We have to adjust it manually. For example: collection to product-collection
 		const dataToUpdate = {...product, ...data};
-		if ('collection' in dataToUpdate) {
-			dataToUpdate['product-collection'] = dataToUpdate.collection;
-			delete dataToUpdate.collection;
+
+		const keysToUpdate = ['collection', 'categories', 'type', 'tags', 'variants', 'options'];
+		for (const key of keysToUpdate) {
+			if (key in dataToUpdate) {
+				dataToUpdate[`product-${key}`] = dataToUpdate[key];
+				delete dataToUpdate[key];
+			}
 		}
 
 		const response = await this.updateEntryInStrapi({
@@ -1324,7 +1328,7 @@ export class UpdateStrapiService extends TransactionBaseService {
 		return { data: result.data.data ?? result.data, status: result.status };
 	}
 
-	/** 
+	/**
 	 * @Todo Create API based access
   async fetchMedusaUserApiKey(emailAddress) {
 

--- a/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
+++ b/packages/medusa-plugin-strapi-ts/src/services/update-strapi.ts
@@ -446,8 +446,9 @@ export class UpdateStrapiService extends TransactionBaseService {
 				return { status: 400 };
 			}
 
-			const collection = await this.productCollectionService.retrieve(data.id);
-			this.logger.info(JSON.stringify(collection));
+			const collection = await this.productCollectionService.retrieve(data.id, {
+				relations: ['products'],
+			});
 
 			if (collection) {
 				// Update entry in Strapi
@@ -786,6 +787,51 @@ export class UpdateStrapiService extends TransactionBaseService {
 		});
 	}
 
+	async updateProductsWithinCollectionInStrapi(data, authInterface: AuthInterface = this.defaultAuthInterface): Promise<StrapiResult> {
+		const hasType = await this.getType('products', authInterface)
+			.then(() => {
+				return true;
+			})
+			.catch(() => {
+				return false;
+			});
+		if (!hasType) {
+			return {status: 400};
+		}
+
+		const updateFields = ['productIds', 'productCollection'];
+
+		if (!this.verifyDataContainsFields(data, updateFields)) {
+			return { status: 400 };
+		}
+		try {
+			for(const productId of data.productIds) {
+				const ignore = await this.shouldIgnore_(productId, 'strapi');
+				if (ignore) {
+					this.logger.info(
+						'Strapi has just added this product to collection which triggered this function. IGNORING... '
+					);
+					continue;
+				}
+
+				const product = await this.productService_.retrieve(productId, {
+					relations: ['collection'],
+					select: ['id'],
+				});
+
+				if (product) {
+					// we're sending requests sequentially as the Strapi is having problems with deadlocks otherwise
+					await this.adjustProductAndUpdateInStrapi(product, data, authInterface);
+				}
+			}
+			return { status: 200 };
+		} catch (error) {
+			this.logger.error("Error updating products in collection", error);
+			throw error;
+		}
+		return { status: 400 };
+	}
+
 	async updateProductInStrapi(data, authInterface: AuthInterface = this.defaultAuthInterface): Promise<StrapiResult> {
 		const hasType = await this.getType('products', authInterface)
 			.then(() => {
@@ -832,16 +878,14 @@ export class UpdateStrapiService extends TransactionBaseService {
 			}
 			const product = await this.productService_.retrieve(data.id, {
 				relations: [
-					// As for now, we can't update relations due to issue with redundant fields
-					// We should pick which fields we want to synchronise from product relations
-					// 'options',
-					// 'variants',
-					// 'variants.prices',
-					// 'variants.options',
-					// 'type',
-					// 'collection',
-					// 'tags',
-					// 'images',
+					'options',
+					'variants',
+					'variants.prices',
+					'variants.options',
+					'type',
+					'collection',
+					'tags',
+					'images',
 				],
 				select: [
 					'id',
@@ -865,19 +909,31 @@ export class UpdateStrapiService extends TransactionBaseService {
 			});
 
 			if (product) {
-				const response = await this.updateEntryInStrapi({
-					type: 'products',
-					id: product.id,
-					authInterface,
-					data: { ...product, ...data },
-					method: 'put',
-				});
-				return response;
+				return await this.adjustProductAndUpdateInStrapi(product, data, authInterface);
 			}
 			return { status: 400 };
 		} catch (error) {
 			throw error;
 		}
+	}
+
+	private async adjustProductAndUpdateInStrapi(product: Product, data, authInterface: AuthInterface) {
+		// Medusa is not using consistent naming for product-collection.
+		// We have to adjust it manually from collection to product-collection
+		const dataToUpdate = {...product, ...data};
+		if ('collection' in dataToUpdate) {
+			dataToUpdate['product-collection'] = dataToUpdate.collection;
+			delete dataToUpdate.collection;
+		}
+
+		const response = await this.updateEntryInStrapi({
+			type: 'products',
+			id: product.id,
+			authInterface,
+			data: dataToUpdate,
+			method: 'put',
+		});
+		return response;
 	}
 
 	async checkType(type, authInterface): Promise<boolean> {
@@ -1516,18 +1572,57 @@ export class UpdateStrapiService extends TransactionBaseService {
 		});
 	}
 
-	translateIdsToMedusaIds(dataToSend: StrapiEntity): StrapiEntity {
+	private isEntity(data: any): boolean {
+		return data instanceof Object && ('id' in data || 'medusa_id' in data);
+	}
+
+	// Medusa is using underscores to represent relations between entities, strapi is using dashes.
+	// This library is translating it in some places but omitting others, this method is providing automatic translation
+	// on every sent request.
+	private translateRelationNamesToStrapiFormat(dataToSend: StrapiEntity, key: string): StrapiEntity {
+		let testObject = null;
+
+		if (_.isArray(dataToSend[key])) {
+			if (dataToSend[key].length > 0) {
+				testObject = dataToSend[key][0];
+			}
+		} else {
+			testObject = dataToSend[key];
+		}
+
+		// if the object is a not empty array or object without id or medusa_id, it's not relation
+		if (testObject && !this.isEntity(testObject)) {
+			return dataToSend;
+		}
+
+		if (key.includes('_')) {
+			dataToSend[key.replace('_', '-')] = dataToSend[key];
+			delete dataToSend[key];
+		}
+
+		return dataToSend;
+	}
+
+	translateDataToStrapiFormat(dataToSend: StrapiEntity): StrapiEntity {
 		const keys = Object.keys(dataToSend);
+		const keysToIgnore = ['id', 'created_at', 'updated_at', 'deleted_at'];
+
 		for (const key of keys) {
 			if (_.isArray(dataToSend[key])) {
 				for (const element of dataToSend[key]) {
-					this.translateIdsToMedusaIds(element);
+					this.isEntity(element) && this.translateDataToStrapiFormat(element);
 				}
+				this.translateRelationNamesToStrapiFormat(dataToSend, key);
 			}
-			if (dataToSend[key] instanceof Object) {
-				this.translateIdsToMedusaIds(dataToSend[key]);
+
+			if (dataToSend[key] instanceof Object && this.isEntity(dataToSend[key])) {
+				this.translateDataToStrapiFormat(dataToSend[key]);
+				this.translateRelationNamesToStrapiFormat(dataToSend, key);
 			} else if (key == 'id') {
 				dataToSend['medusa_id'] = dataToSend[key];
+			}
+
+			if (this.isEntity(dataToSend) && keysToIgnore.includes(key)) {
 				delete dataToSend[key];
 			}
 		}
@@ -1548,9 +1643,7 @@ export class UpdateStrapiService extends TransactionBaseService {
 		let dataToSend: BaseEntity & { medusa_id?: string };
 		if (data && data.id) {
 			dataToSend = _.cloneDeep(data);
-			dataToSend = this.translateIdsToMedusaIds(dataToSend);
-			dataToSend['medusa_id'] = data.id;
-			delete dataToSend.id;
+			dataToSend = this.translateDataToStrapiFormat(dataToSend);
 		} else {
 			dataToSend = data;
 		}

--- a/packages/medusa-plugin-strapi-ts/src/subscribers/strapi.ts
+++ b/packages/medusa-plugin-strapi-ts/src/subscribers/strapi.ts
@@ -101,6 +101,24 @@ class StrapiSubscriber {
 		);
 
 		this.eventBus_.subscribe(
+			ProductCollectionService.Events.PRODUCTS_ADDED,
+			async (data: BaseEntity & { data: Record<string, unknown> }) => {
+				const authInterace: AuthInterface =
+					(await this.getLoggedInUserStrapiCreds()) ?? this.strapiService_.defaultAuthInterface;
+				await this.strapiService_.updateProductsWithinCollectionInStrapi(data.id, authInterace);
+			}
+		);
+
+		this.eventBus_.subscribe(
+			ProductCollectionService.Events.PRODUCTS_REMOVED,
+			async (data: BaseEntity & { data: Record<string, unknown> }) => {
+				const authInterace: AuthInterface =
+					(await this.getLoggedInUserStrapiCreds()) ?? this.strapiService_.defaultAuthInterface;
+				await this.strapiService_.updateProductsWithinCollectionInStrapi(data.id, authInterace);
+			}
+		);
+
+		this.eventBus_.subscribe(
 			ProductCategoryService.Events.UPDATED,
 			async (data: BaseEntity & { data: Record<string, unknown> }) => {
 				const authInterace: AuthInterface =

--- a/packages/medusa-strapi/src/api/product-collection/content-types/product-collection/schema.json
+++ b/packages/medusa-strapi/src/api/product-collection/content-types/product-collection/schema.json
@@ -35,9 +35,9 @@
     },
     "products": {
       "type": "relation",
-      "relation": "manyToMany",
+      "relation": "oneToMany",
       "target": "api::product.product",
-      "inversedBy": "product-collections"
+      "mappedBy": "product-collection"
     }
   }
 }

--- a/packages/medusa-strapi/src/api/product/content-types/product/schema.json
+++ b/packages/medusa-strapi/src/api/product/content-types/product/schema.json
@@ -108,11 +108,11 @@
       "target": "api::image.image",
       "mappedBy": "product"
     },
-    "product-collections": {
+    "product-collection": {
       "type": "relation",
-      "relation": "manyToMany",
+      "relation": "manyToOne",
       "target": "api::product-collection.product-collection",
-      "mappedBy": "products"
+      "inversedBy": "products"
     },
     "product-categories": {
       "type": "relation",
@@ -120,7 +120,6 @@
       "target": "api::product-category.product-category",
       "mappedBy": "products"
     },
-    
     "product-type": {
       "type": "relation",
       "relation": "manyToOne",


### PR DESCRIPTION
Updated services to handle product collections and products in Strapi; also fixed some other major bugs.

**Major changes:**

In the update-strapi.ts file:

- Reverted "relation" comments from product updates.
- Added a new method, `updateProductsWithinCollectionInStrapi`, to update products within a collection in Strapi when they're added or removed from collections.
- Added a private method `adjustProductAndUpdateInStrapi` to decouple product adjusting as it's now shared by two methods - there is an edge case in naming created by the Medusa team.
- Updated the `translateDataToStrapiFormat` method to translate underscores in relation names to dashes for consistency globally.

In the strapi.ts file:

- Added event subscribers for the `PRODUCTS_ADDED` and `PRODUCTS_REMOVED` events of the ProductCollectionService.
- Implemented logic to update products within a collection in Strapi when products are added or removed.

In the schema.json files:

- There was a bug in the relation between product and product collections. This prevented it from populating the data. 
- Updated the product and product-collection schema to change the relationship type from manyToMany to oneToMany and similarly in the product schema.

In the utils.js file:

- Used `attachOrCreateStrapiIdFromMedusaId` function in the Update controller to handle nested relations

These changes enhance the functionality of the Medusa Plugin for Strapi by better handling product collections, products in the Strapi backend and to bring back the "nested update" functionality. 