### PR TITLE
fix: clean command not finding rimraf

### DIFF
--- a/packages/medusa-plugin-strapi-ts/package.json
+++ b/packages/medusa-plugin-strapi-ts/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "scripts": {
     "integration-test": "yarn test",
-    "clean": "./node_modules/.bin/rimraf dist/ types/ services/ models/ migrations/ api/ subscribers/ utils/ index.js index.map.js",
+    "clean": "npx rimraf dist/ types/ services/ models/ migrations/ api/ subscribers/ utils/ index.js index.map.js",
     "build": "npm run clean && tsc -p tsconfig.json",
     "watch": "tsc --watch",
     "test": "jest --coverage --runInBand --setupFiles=dotenv/config "


### PR DESCRIPTION
When I tried to run the `build` command in the monorepo, I got the following error:

```
medusa-plugin-strapi-ts: > medusa-plugin-strapi-ts@5.0.21 clean
medusa-plugin-strapi-ts: > ./node_modules/.bin/rimraf dist/ types/ services/ models/ migrations/ api/ subscribers/ utils/ index.js index.map.js
medusa-plugin-strapi-ts: sh: ./node_modules/.bin/rimraf: No such file or directory
```

That's because `rimraf` was installed in the root of the monorepo rather than in the `medusa-plugin-strapi-ts` package.

By changing the command to use `npx`, the path to `rimraf` will be inferred without having to guess where it's located.